### PR TITLE
Added support to watch uploads

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -268,7 +268,7 @@ def FollowedChannelsList(apiurl=None, limit=100, **kwargs):
     return oc
 
 
-@route(PREFIX + '/channel/vods', broadcasts=bool, uploads=bool, limit=int)
+@route(PREFIX + '/channel/vods', broadcastType=String, limit=int)
 def ChannelVodsList(name=None, apiurl=None, broadcastType=BroadcastType.HIGHLIGHT, limit=PAGE_LIMIT, **kwargs):
     """Returns videoClipObjects for ``channel``. ignore vods that aren't v type."""
     oc = ObjectContainer(title2=L('title_'+broadcastType))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -22,6 +22,11 @@ ICONS = {'search':    R('ic_search_c.png'),
          'authorize': R('ic_settings_c.png')}
 
 
+class BroadcastType:
+    ARCHIVE = 'archive'
+    UPLOAD = 'upload'
+    HIGHLIGHT = 'highlight'
+
 def Start():
     ObjectContainer.title1 = NAME
     ObjectContainer.art = R(ART)
@@ -216,14 +221,14 @@ def ChannelMenu(channel_name, stream=None, **kwargs):
     if stream is not None:
         oc.add(stream_vid(stream))  # Watch Live
     # Highlights
-    oc.add(DirectoryObject(key=Callback(ChannelVodsList, name=channel_name, broadcasts=False, uploads=False),
-                           title=unicode(L('highlights')), thumb=ICONS['videos']))
+    oc.add(DirectoryObject(key=Callback(ChannelVodsList, name=channel_name, broadcastType=BroadcastType.HIGHLIGHT),
+                           title=unicode(L('title_highlight')), thumb=ICONS['videos']))
     # Past Broadcasts
-    oc.add(DirectoryObject(key=Callback(ChannelVodsList, name=channel_name, broadcasts=True, uploads=False),
-                           title=unicode(L('past_broadcasts')), thumb=ICONS['videos']))
+    oc.add(DirectoryObject(key=Callback(ChannelVodsList, name=channel_name, broadcastType=BroadcastType.ARCHIVE),
+                           title=unicode(L('title_archive')), thumb=ICONS['videos']))
     # Uploads
-    oc.add(DirectoryObject(key=Callback(ChannelVodsList, name=channel_name, broadcasts=False, uploads=True),
-                           title=unicode(L('uploads')), thumb=ICONS['videos']))
+    oc.add(DirectoryObject(key=Callback(ChannelVodsList, name=channel_name, broadcastType=BroadcastType.UPLOAD),
+                           title=unicode(L('title_upload')), thumb=ICONS['videos']))
     return oc
 
 
@@ -264,19 +269,9 @@ def FollowedChannelsList(apiurl=None, limit=100, **kwargs):
 
 
 @route(PREFIX + '/channel/vods', broadcasts=bool, uploads=bool, limit=int)
-def ChannelVodsList(name=None, apiurl=None, broadcasts=True, uploads=False, limit=PAGE_LIMIT, **kwargs):
+def ChannelVodsList(name=None, apiurl=None, broadcastType=BroadcastType.HIGHLIGHT, limit=PAGE_LIMIT, **kwargs):
     """Returns videoClipObjects for ``channel``. ignore vods that aren't v type."""
-    if broadcasts:
-        pageTitle = L('past_broadcasts')
-        broadcastType = 'archive'
-    elif uploads:
-        pageTitle = L('uploads')
-        broadcastType = 'upload'
-    else:
-        pageTitle = L('highlights')
-        broadcastType = 'highlight'
-
-    oc = ObjectContainer(title2=pageTitle)
+    oc = ObjectContainer(title2=L('title_'+broadcastType))
     try:
         videos = (api_request(apiurl) if apiurl is not None else
                   api_request('/channels/{}/videos'.format(name),
@@ -299,7 +294,7 @@ def ChannelVodsList(name=None, apiurl=None, broadcasts=True, uploads=False, limi
                                                                         fallback=ICONS['videos'])))
     if len(oc) + ignored >= limit:
         oc.add(NextPageObject(key=Callback(ChannelVodsList, apiurl=videos['_links']['next'],
-                                           broadcasts=broadcasts, limit=limit),
+                                           broadcastType=broadcastType, limit=limit),
                               title=unicode(L('more')), thumb=ICONS['more']))
     return oc
 

--- a/Contents/Strings/en.json
+++ b/Contents/Strings/en.json
@@ -8,13 +8,11 @@
     "search": "Search",
     "search_prompt": "Search for",
     "browse_summary": "Browse Live Streams by Game",
-    "past_broadcasts": "Past Broadcasts",
     "more": "More...",
     "channels": "Channels",
     "streams": "Streams",
     "viewers": "Viewers",
     "watch_stream": "Watch Stream",
-    "highlights": "Highlights",
     "live": "LIVE",
     "offline": "OFFLINE",
     "followed_streams_list_error": "Error getting the list of followed streams.",
@@ -38,5 +36,7 @@
     "access_token": "Access Token (optional)",
     "authorize": "Authorize",
     "hide_offline": "Hide Offline Channels",
-    "uploads": "Uploads"
+    "title_archive": "Past Broadcasts",
+    "title_highlight": "Highlights",
+    "title_upload": "Uploads"
 }

--- a/Contents/Strings/en.json
+++ b/Contents/Strings/en.json
@@ -37,5 +37,6 @@
     "Channel updated to version %s": "Channel updated to version %s",
     "access_token": "Access Token (optional)",
     "authorize": "Authorize",
-    "hide_offline": "Hide Offline Channels"
+    "hide_offline": "Hide Offline Channels",
+    "uploads": "Uploads"
 }


### PR DESCRIPTION
Twitch added a possibilty to upload videos a while ago. VODs can now
either be of type highlight, archive or upload. In order to be able
to see them the query must use the new 'broadcast_type' parameter.

This plugin will now display all uploads of a channel in a sepate list
similar to how it was done so far for past broadcasts or highlights.